### PR TITLE
Basic auth from Apibuilder attribute (remove hardcoded one)

### DIFF
--- a/postman-generator/src/main/scala/examples/ExampleJson.scala
+++ b/postman-generator/src/main/scala/examples/ExampleJson.scala
@@ -4,8 +4,8 @@ import java.util.UUID
 
 import io.apibuilder.spec.v0.models._
 import io.apibuilder.spec.v0.models.json._
-import models.ObjectReferenceAttribute
-import models.ObjectReferenceAttribute.ObjectReferenceAttrValue
+import models.attributes.ObjectReferenceAttribute.ObjectReferenceAttrValue
+import models.attributes.ObjectReferenceAttribute
 import org.joda.time.{DateTime, LocalDate}
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json._

--- a/postman-generator/src/main/scala/generator/DependantOperationResolver.scala
+++ b/postman-generator/src/main/scala/generator/DependantOperationResolver.scala
@@ -1,8 +1,8 @@
 package generator
 
 import io.apibuilder.spec.v0.models.{Operation, Resource, Service}
-import models.ObjectReferenceAttribute
-import models.ObjectReferenceAttribute.ObjectReferenceAttrValue
+import models.attributes.ObjectReferenceAttribute.ObjectReferenceAttrValue
+import models.attributes.ObjectReferenceAttribute
 import models.service.ResolvedService
 
 object DependantOperationResolver {

--- a/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
+++ b/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
@@ -5,12 +5,14 @@ import generator.Heuristics.PathVariable
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import io.apibuilder.spec.v0.models._
 import lib.generator.CodeGenerator
-import models.ObjectReferenceAttribute.ObjectReferenceAttrValue
-import io.flow.postman.collection.v210.v0.{models=>postman}
+import models.attributes.ObjectReferenceAttribute.ObjectReferenceAttrValue
+import io.flow.postman.collection.v210.v0.{models => postman}
 import io.flow.postman.collection.v210.v0.models.json._
 import models.service.{ResolvedService, ServiceImportResolver}
 import play.api.libs.json.Json
 import Utils._
+import models.attributes.PostmanBasicAuthAttribute
+import models.attributes.PostmanBasicAuthAttribute.PostmanBasicAuthAttrValue
 
 object PostmanCollectionGenerator extends CodeGenerator {
 
@@ -106,6 +108,19 @@ object PostmanCollectionGenerator extends CodeGenerator {
       item = setupFolder.item ++ requiredEntitiesSetupSteps
     )
 
+    val basicAuthOpt = service.attributes.collectFirst {
+      case basicAuthAttr if basicAuthAttr.name.equalsIgnoreCase(PostmanBasicAuthAttribute.Key) =>
+        basicAuthAttr.value.asOpt[PostmanBasicAuthAttrValue]
+    }.flatten.map { basicAuth =>
+      postman.Auth(
+        `type` = postman.AuthEnum.Basic,
+        basic = Some(List(
+          postman.BasicAuth(key = "username", value = basicAuth.username),
+          postman.BasicAuth(key = "password", value = basicAuth.password)
+        ))
+      )
+    }
+
     postman.Collection(
       info = collectionInfo,
       item = postmanCollectionFolders, // TODO: remove after fixing hardcodes .:+(cleanupFolder).+:(setupFolderWithDependantEntities),
@@ -116,14 +131,7 @@ object PostmanCollectionGenerator extends CodeGenerator {
           `type` = "string"
         )
       ),
-      auth =
-        Some(postman.Auth(
-        `type` = postman.AuthEnum.Basic,
-        basic = Some(List(
-          postman.BasicAuth(key = "username", value = s"{{${Variables.FlowToken}}}"),
-          postman.BasicAuth(key = "password", value = "")
-        ))
-      )),
+      auth = basicAuthOpt,
       event = Seq.empty
     )
   }

--- a/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
+++ b/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
@@ -108,10 +108,10 @@ object PostmanCollectionGenerator extends CodeGenerator {
       item = setupFolder.item ++ requiredEntitiesSetupSteps
     )
 
-    val basicAuthOpt = service.attributes.collectFirst {
-      case basicAuthAttr if basicAuthAttr.name.equalsIgnoreCase(PostmanBasicAuthAttribute.Key) =>
-        basicAuthAttr.value.asOpt[PostmanBasicAuthAttrValue]
-    }.flatten.map { basicAuth =>
+    val basicAuthOpt = service.attributes
+      .find(_.name.equalsIgnoreCase(PostmanBasicAuthAttribute.Key))
+      .flatMap(_.value.asOpt[PostmanBasicAuthAttrValue])
+      .map { basicAuth =>
       postman.Auth(
         `type` = postman.AuthEnum.Basic,
         basic = Some(List(

--- a/postman-generator/src/main/scala/models/attributes/ObjectReferenceAttribute.scala
+++ b/postman-generator/src/main/scala/models/attributes/ObjectReferenceAttribute.scala
@@ -1,4 +1,4 @@
-package models
+package models.attributes
 
 import _root_.play.api.libs.json.Json
 

--- a/postman-generator/src/main/scala/models/attributes/PostmanBasicAuthAttribute.scala
+++ b/postman-generator/src/main/scala/models/attributes/PostmanBasicAuthAttribute.scala
@@ -1,0 +1,15 @@
+package models.attributes
+
+import play.api.libs.json.Json
+
+object PostmanBasicAuthAttribute {
+
+  val Key = "postman-basic-auth"
+
+  case class PostmanBasicAuthAttrValue(
+    username: String,
+    password: String
+  )
+
+  implicit val postmanBasicAuthAttrValueFormat = Json.format[PostmanBasicAuthAttrValue]
+}

--- a/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
+++ b/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
@@ -5,8 +5,11 @@ import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import io.apibuilder.spec.v0.models._
 import io.flow.postman.collection.v210.v0.{models => postman}
 import io.flow.postman.collection.v210.v0.models.json.jsonReadsPostmanCollectionV210Collection
+import models.attributes.PostmanBasicAuthAttribute
+import models.attributes.PostmanBasicAuthAttribute.PostmanBasicAuthAttrValue
+import models.attributes.PostmanBasicAuthAttribute.postmanBasicAuthAttrValueFormat
 import org.scalatest.{Assertion, Matchers, WordSpec}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 import scala.util.Try
 
@@ -31,7 +34,7 @@ class PostmanCollectionGeneratorSpec extends WordSpec with Matchers {
       result.isRight shouldEqual true
 
       val generatedCollectionJson = Json.parse(result.right.get.head.contents)
-      // TODO: below JSON contains 'variable' and 'auth' elements that are hardcoded now. delete after fixing the logic
+      // TODO: below JSON contains 'variable' element that is hardcoded now. delete after fixing the logic
       generatedCollectionJson shouldEqual Json.parse(
         """
           |{
@@ -65,16 +68,6 @@ class PostmanCollectionGeneratorSpec extends WordSpec with Matchers {
           |    "name" : "complex-strings",
           |    "type" : "folder"
           |  } ],
-          |  "auth" : {
-          |    "type" : "basic",
-          |    "basic" : [ {
-          |      "value" : "{{FLOW_TOKEN}}",
-          |      "key" : "username"
-          |    }, {
-          |      "value" : "",
-          |      "key" : "password"
-          |    } ]
-          |  },
           |  "variable" : [ {
           |    "type" : "string",
           |    "value" : "https://some.service.com",
@@ -149,6 +142,30 @@ class PostmanCollectionGeneratorSpec extends WordSpec with Matchers {
         val responseExampleJson = Json.parse(getFirstAgeGroupEndpointResponseExample.body.get)
         val exampleGroup = (responseExampleJson \ "group").as[String]
         importedEnum.values.map(_.name) should contain(exampleGroup)
+      }
+    }
+
+    "add Basic Auth definition to the Collection if the specification contains postman-basic-auth attribute" in new TrivialServiceContext {
+      val basicAuthAttrValue = PostmanBasicAuthAttrValue(
+        username = "{{USER}}",
+        password = ""
+      )
+      val trivialServiceWithAuth = trivialService.copy(
+        attributes = Seq(
+          Attribute(name = PostmanBasicAuthAttribute.Key, value = Json.toJson(basicAuthAttrValue).as[JsObject])
+        )
+      )
+
+      val invocationForm = InvocationForm(trivialServiceWithAuth, importedServices = Some(Seq(referenceApiService)))
+      val result = PostmanCollectionGenerator.invoke(invocationForm)
+
+      assertResultCollectionJson(result) { collection =>
+        collection.auth.isDefined shouldEqual true
+        collection.auth.get.`type` shouldEqual postman.AuthEnum.Basic
+        collection.auth.get.basic.get shouldEqual Seq(
+          postman.BasicAuth(key = "username", value = basicAuthAttrValue.username),
+          postman.BasicAuth(key = "password", value = basicAuthAttrValue.password)
+        )
       }
     }
 

--- a/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
+++ b/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
@@ -34,7 +34,6 @@ class PostmanCollectionGeneratorSpec extends WordSpec with Matchers {
       result.isRight shouldEqual true
 
       val generatedCollectionJson = Json.parse(result.right.get.head.contents)
-      // TODO: below JSON contains 'variable' element that is hardcoded now. delete after fixing the logic
       generatedCollectionJson shouldEqual Json.parse(
         """
           |{


### PR DESCRIPTION
adds Basic Auth definition to postman according to the custom attribute from Apibuilder specification.
WARNING: there are currently some problems with uploading spec that contains `attributes` field.