### PR TITLE
cover ServiceImportResolver with unit test suite, fix 2 existing bugs

### DIFF
--- a/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
+++ b/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
@@ -8,7 +8,7 @@ import lib.generator.CodeGenerator
 import models.attributes.PostmanAttributes.ObjectReferenceAttrValue
 import io.flow.postman.collection.v210.v0.{models => postman}
 import io.flow.postman.collection.v210.v0.models.json._
-import models.service.{ResolvedService, ServiceImportResolver}
+import models.service.ResolvedService
 import play.api.libs.json.Json
 import Utils._
 import io.flow.postman.collection.v210.v0.models.Folder
@@ -35,11 +35,8 @@ object PostmanCollectionGenerator extends CodeGenerator {
   private def invokeGenerator(service: Service, importedServices: Seq[Service]): Either[Seq[String], Seq[File]] = {
 
     val resolvedService: ResolvedService = ServiceImportResolver.resolveService(service, importedServices)
-
     val postmanCollectionJson = generatePostmanCollection(resolvedService)
-
-    val postmanCollectionFileName = s"${service.name}-postman-collection.json"
-    val savedFile = writePostmanCollectionToFile(service, postmanCollectionFileName, postmanCollectionJson)
+    val savedFile = writePostmanCollectionToFile(service, postmanCollectionJson)
 
     Right(Seq(savedFile))
   }
@@ -226,7 +223,7 @@ object PostmanCollectionGenerator extends CodeGenerator {
 
   }
 
-  private def writePostmanCollectionToFile(service: Service, fileName: String, postmanCollection: postman.Collection): File = {
+  private def writePostmanCollectionToFile(service: Service, postmanCollection: postman.Collection): File = {
 
     val postmanCollectionJson = Json.toJson(postmanCollection)
     val jsonPrettyPrint = Json.prettyPrint(postmanCollectionJson) + "\n"

--- a/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
+++ b/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
@@ -2,7 +2,6 @@ package generator
 
 import generator.Utils.Description
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
-import io.apibuilder.spec.v0.models._
 import io.flow.postman.collection.v210.v0.{models => postman}
 import io.flow.postman.collection.v210.v0.models.json.jsonReadsPostmanCollectionV210Collection
 import models.attributes.PostmanAttributes
@@ -15,6 +14,7 @@ import scala.util.Try
 
 class PostmanCollectionGeneratorSpec extends WordSpec with Matchers {
 
+  import TestFixtures._
   import models.TestHelper._
 
   "PostmanCollectionGenerator" should {
@@ -192,95 +192,6 @@ class PostmanCollectionGeneratorSpec extends WordSpec with Matchers {
     val postmanCollection = Json.parse(resultFile.contents).as[postman.Collection]
 
     collectionAssertion(postmanCollection)
-  }
-
-  trait TrivialServiceContext {
-    val trivialService = Service(
-      apidoc = Apidoc("0.1"),
-      name = "trivial",
-      organization = Organization("test-org"),
-      application = Application("test-app"),
-      namespace = "io.trivial",
-      version = "0.1",
-      info = Info(license = None, contact = None),
-      models = Seq(
-        Model(
-          name = "complex-string",
-          plural = "complex-strings",
-          fields = Seq(
-            Field(
-              name = "value",
-              `type` = "string",
-              example = Some("something"),
-              required = true
-            )
-          ))
-      ),
-      resources = Seq(
-        Resource(
-          `type` = "complex-string",
-          plural = "complex-strings",
-          operations = Seq(
-            Operation(
-              method = Method.Post,
-              path = "/complex-strings/new",
-              body = Some(
-                Body(`type` = "complex-string")
-              )
-            )
-          )
-        )
-      ),
-      baseUrl = Some("https://some.service.com")
-    )
-
-  }
-
-  trait TrivialServiceWithImportCtx extends TrivialServiceContext {
-    val importedEnum = referenceApiService.enums.find(_.name == "age_group")
-      .getOrElse(fail("age_group enum is expected in example reference-service.json"))
-    val importedEnumPath = s"${referenceApiService.namespace}.enums.age_group"
-
-    val trivialServiceWithImport = trivialService.copy(
-      imports = Seq(
-        Import(
-          uri = "some-uri",
-          namespace = referenceApiService.name,
-          organization = referenceApiService.organization,
-          application = referenceApiService.application,
-          version = referenceApiService.version,
-          enums = Seq("age_group")
-        )
-      ),
-      models = trivialService.models :+ Model(
-        name = "age",
-        plural = "ages",
-        fields = Seq(
-          Field(
-            name = "group",
-            `type` = importedEnumPath,
-            required = true
-          )
-        )
-      ),
-      resources = trivialService.resources :+ Resource(
-        `type` = "age",
-        plural = "ages",
-        operations = Seq(
-          Operation(
-            method = Method.Get,
-            path = "/ages/first",
-            responses = Seq(
-              Response(
-                code = ResponseCodeInt(200),
-                `type` = "age"
-              )
-            )
-          )
-        )
-      )
-    )
-
   }
 
 }

--- a/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
+++ b/postman-generator/src/test/scala/generator/PostmanCollectionGeneratorSpec.scala
@@ -2,6 +2,7 @@ package generator
 
 import generator.Utils.Description
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
+import io.apibuilder.spec.v0.models.Attribute
 import io.flow.postman.collection.v210.v0.{models => postman}
 import io.flow.postman.collection.v210.v0.models.json.jsonReadsPostmanCollectionV210Collection
 import models.attributes.PostmanAttributes

--- a/postman-generator/src/test/scala/generator/ServiceImportResolverSpec.scala
+++ b/postman-generator/src/test/scala/generator/ServiceImportResolverSpec.scala
@@ -1,0 +1,132 @@
+package generator
+
+import examples.ExampleJson
+import org.scalatest.{Matchers, WordSpec}
+
+class ServiceImportResolverSpec extends WordSpec with Matchers {
+
+  import TestFixtures._
+
+  "ServiceImportResolver" should {
+
+    "return the same service untouched if importedServices array is empty" in new TrivialServiceContext {
+      val result = ServiceImportResolver.resolveService(trivialService, Seq.empty)
+
+      result.service shouldEqual trivialService
+    }
+
+    "return a service with empty imports list" in new ResolvedServiceTestContext {
+      result.service.imports.isEmpty shouldEqual true
+    }
+
+    "return a service, which enums, models and unions count equal the used services components sum" in new ResolvedServiceTestContext {
+      resultService.enums.length shouldEqual mainService.enums.length + importedService.enums.length
+      resultService.models.length shouldEqual mainService.models.length + importedService.models.length
+      resultService.unions.length shouldEqual mainService.unions.length + importedService.unions.length
+    }
+
+    "group all resources into one map" in new ResolvedServiceTestContext {
+      resultService.resources shouldEqual mainService.resources
+      result.serviceNamespaceToResources shouldEqual Map(
+        mainService.namespace -> mainService.resources,
+        importedService.namespace -> importedService.resources
+      )
+    }
+
+    "leave the enums, models, unions type intact if it comes from the main service" in new ResolvedServiceTestContext {
+      val enumsIntact = mainService.enums.forall(enum => resultService.enums.exists(_.name == enum.name))
+      enumsIntact shouldEqual true
+
+      val modelsIntact = mainService.models.forall(model => resultService.models.exists(_.name == model.name))
+      modelsIntact shouldEqual true
+
+      val unionsIntact = mainService.unions.forall(union => resultService.unions.exists(_.name == union.name))
+      unionsIntact shouldEqual true
+    }
+
+    "rename the merged enums, models, unions type to the full namespace+name" in new ResolvedServiceTestContext {
+      val enumNamesWithFullNamespace = importedService.enums.forall { enum =>
+        resultService.enums.exists(e => e.name.contains(importedService.namespace) && e.name.contains(enum.name))
+      }
+      enumNamesWithFullNamespace shouldEqual true
+
+      val modelNamesWithFullNamespace = importedService.models.forall { model =>
+        resultService.models.exists(m => m.name.contains(importedService.namespace) && m.name.contains(model.name))
+      }
+      modelNamesWithFullNamespace shouldEqual true
+
+      val unionNamesWithFullNamespace = importedService.unions.forall { union =>
+        resultService.unions.exists(u => u.name.contains(importedService.namespace) && u.name.contains(union.name))
+      }
+      unionNamesWithFullNamespace shouldEqual true
+    }
+
+    "rename complex field types in the imported models so they match the full namespace+type" in new ResolvedServiceTestContext {
+      val fieldNameToTypeMap = importedService.models.flatMap(_.fields).map(f => (f.name, f.`type`)).toMap
+      val fieldNamesToCheck = fieldNameToTypeMap.filter {
+        case (_, typ) => importedService.models.map(_.name).exists(n => typ.contains(n))
+      }.keys.toList
+
+      val updatedFieldsToTest = resultService.models.flatMap(_.fields)
+        .filter(f => fieldNamesToCheck.contains(f.name))
+
+      updatedFieldsToTest.foreach { field =>
+        field.`type` should include(importedService.namespace)
+      }
+    }
+
+    "prepare models in a way, which enables ExampleJson to prepare a sample JSON for every single one of them" in new ResolvedServiceTestContext {
+      val exampleProvider = ExampleJson.allFields(resultService)
+      resultService.models.foreach { model =>
+        val exampleProvided = exampleProvider.sample(model.name).isDefined
+        assert(exampleProvided, s"// it should provide an example for ${model.name}")
+      }
+    }
+
+    "rename complex types in the imported models so they match the full namespace+type" in new ResolvedServiceWithUnionsTestContext {
+      val unionNameToTypesMap = importedService.unions.map(u => (u.name, u.types)).toMap
+      val typesDefinedInService = importedService.models.map(_.name) ++ importedService.enums.map(_.name)
+      val unionNameToTypesMapToCheck = unionNameToTypesMap.map {
+        case (name, types) =>
+          val filteredTypes = types.filter(typ => typesDefinedInService.exists(n => typ.`type`.contains(n)))
+          (name, filteredTypes)
+      }
+      val updatedUnionTypesToTest = resultService.unions
+        .filter(u => unionNameToTypesMapToCheck.keys.exists(k => u.name.contains(k)))
+        .flatMap { union =>
+          union.types.filter { typ =>
+            unionNameToTypesMapToCheck.values.flatten.exists(u => typ.`type`.contains(u.`type`))
+          }
+        }
+
+      updatedUnionTypesToTest.foreach { typ =>
+        typ.`type` should include(importedService.namespace)
+      }
+    }
+
+    "prepare unions in a way, which enables ExampleJson to prepare a sample JSON for every single one of them" in new ResolvedServiceWithUnionsTestContext {
+      val exampleProvider = ExampleJson.allFields(resultService)
+      resultService.unions.foreach { union =>
+        val exampleProvided = exampleProvider.sample(union.name).isDefined
+        assert(exampleProvided, s"// it should provide an example for ${union.name}")
+      }
+    }
+  }
+
+  trait ResolvedServiceTestContext extends TrivialServiceWithImportCtx {
+    val mainService = trivialServiceWithImport
+    val importedService = models.TestHelper.referenceApiService
+
+    lazy val result = ServiceImportResolver.resolveService(mainService, Seq(importedService))
+    lazy val resultService = result.service
+  }
+
+  trait ResolvedServiceWithUnionsTestContext extends TrivialServiceWithUnionTypesImportCtx {
+    val mainService = trivialServiceWithUnionTypesImport
+    val importedService = models.TestHelper.generatorApiServiceWithUnionWithoutDescriminator
+
+    lazy val result = ServiceImportResolver.resolveService(mainService, Seq(importedService))
+    lazy val resultService = result.service
+  }
+
+}

--- a/postman-generator/src/test/scala/generator/ServiceImportResolverSpec.scala
+++ b/postman-generator/src/test/scala/generator/ServiceImportResolverSpec.scala
@@ -83,7 +83,7 @@ class ServiceImportResolverSpec extends WordSpec with Matchers {
       }
     }
 
-    "rename complex types in the imported models so they match the full namespace+type" in new ResolvedServiceWithUnionsTestContext {
+    "rename complex types in the imported unions so they match the full namespace+type" in new ResolvedServiceWithUnionsTestContext {
       val unionNameToTypesMap = importedService.unions.map(u => (u.name, u.types)).toMap
       val typesDefinedInService = importedService.models.map(_.name) ++ importedService.enums.map(_.name)
       val unionNameToTypesMapToCheck = unionNameToTypesMap.map {

--- a/postman-generator/src/test/scala/generator/TestFixtures.scala
+++ b/postman-generator/src/test/scala/generator/TestFixtures.scala
@@ -6,7 +6,6 @@ object TestFixtures {
 
   import models.TestHelper.{referenceApiService, generatorApiServiceWithUnionWithoutDescriminator}
 
-
   trait TrivialServiceContext {
     val trivialService = Service(
       apidoc = Apidoc("0.1"),

--- a/postman-generator/src/test/scala/generator/TestFixtures.scala
+++ b/postman-generator/src/test/scala/generator/TestFixtures.scala
@@ -1,0 +1,147 @@
+package generator
+
+import io.apibuilder.spec.v0.models._
+
+object TestFixtures {
+
+  import models.TestHelper.{referenceApiService, generatorApiServiceWithUnionWithoutDescriminator}
+
+
+  trait TrivialServiceContext {
+    val trivialService = Service(
+      apidoc = Apidoc("0.1"),
+      name = "trivial",
+      organization = Organization("test-org"),
+      application = Application("test-app"),
+      namespace = "io.trivial",
+      version = "0.1",
+      info = Info(license = None, contact = None),
+      models = Seq(
+        Model(
+          name = "complex-string",
+          plural = "complex-strings",
+          fields = Seq(
+            Field(
+              name = "value",
+              `type` = "string",
+              example = Some("something"),
+              required = true
+            )
+          ))
+      ),
+      resources = Seq(
+        Resource(
+          `type` = "complex-string",
+          plural = "complex-strings",
+          operations = Seq(
+            Operation(
+              method = Method.Post,
+              path = "/complex-strings/new",
+              body = Some(
+                Body(`type` = "complex-string")
+              )
+            )
+          )
+        )
+      ),
+      baseUrl = Some("https://some.service.com")
+    )
+
+  }
+
+  trait TrivialServiceWithImportCtx extends TrivialServiceContext {
+    val importedEnum = referenceApiService.enums.find(_.name == "age_group")
+      .getOrElse(throw new NoSuchElementException("age_group enum is expected in example reference-service.json"))
+    val importedEnumPath = s"${referenceApiService.namespace}.enums.age_group"
+
+    val trivialServiceWithImport = trivialService.copy(
+      imports = Seq(
+        Import(
+          uri = "some-uri",
+          namespace = referenceApiService.name,
+          organization = referenceApiService.organization,
+          application = referenceApiService.application,
+          version = referenceApiService.version,
+          enums = Seq("age_group")
+        )
+      ),
+      models = trivialService.models :+ Model(
+        name = "age",
+        plural = "ages",
+        fields = Seq(
+          Field(
+            name = "group",
+            `type` = importedEnumPath,
+            required = true
+          )
+        )
+      ),
+      resources = trivialService.resources :+ Resource(
+        `type` = "age",
+        plural = "ages",
+        operations = Seq(
+          Operation(
+            method = Method.Get,
+            path = "/ages/first",
+            responses = Seq(
+              Response(
+                code = ResponseCodeInt(200),
+                `type` = "age"
+              )
+            )
+          )
+        )
+      )
+    )
+
+  }
+  
+  trait TrivialServiceWithUnionTypesImportCtx extends TrivialServiceContext {
+
+    val unionType = "foobar"
+    val importedUnion = generatorApiServiceWithUnionWithoutDescriminator.unions.find(_.name == unionType)
+      .getOrElse(throw new NoSuchElementException(s"$unionType is expected in example apidoc-example-union-types.json"))
+    val importedUnionPath = s"${generatorApiServiceWithUnionWithoutDescriminator.namespace}.unions.$unionType"
+
+    val trivialServiceWithUnionTypesImport = trivialService.copy(
+      imports = Seq(
+        Import(
+          uri = "some-uri",
+          namespace = generatorApiServiceWithUnionWithoutDescriminator.name,
+          organization = generatorApiServiceWithUnionWithoutDescriminator.organization,
+          application = generatorApiServiceWithUnionWithoutDescriminator.application,
+          version = generatorApiServiceWithUnionWithoutDescriminator.version,
+          unions = Seq(unionType)
+        )
+      ),
+      models = trivialService.models :+ Model(
+        name = "union",
+        plural = "unions",
+        fields = Seq(
+          Field(
+            name = "my-union",
+            `type` = importedUnionPath,
+            required = true
+          )
+        )
+      ),
+      resources = trivialService.resources :+ Resource(
+        `type` = "union",
+        plural = "unions",
+        operations = Seq(
+          Operation(
+            method = Method.Get,
+            path = "/unions/my",
+            responses = Seq(
+              Response(
+                code = ResponseCodeInt(200),
+                `type` = "union"
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
- added ServiceImportResolverSpec
- extracted test fixtures (custom services for testing) to a separate file that can be shared across different files
- found and fixed 2 bugs in ServiceImportResolver