### PR TITLE
undeterministic random string generator in runtime

### DIFF
--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -405,7 +405,7 @@ object Generators {
         language = Some("json")
       ),
       status = lib.generator.Status.InDevelopment,
-      codeGenerator = Some(generator.PostmanCollectionGenerator)
+      codeGenerator = Some(generator.PostmanCollectionGeneratorImpl)
     )
   ).sortBy(_.metaData.key)
 }

--- a/postman-generator/src/main/scala/examples/ExampleJson.scala
+++ b/postman-generator/src/main/scala/examples/ExampleJson.scala
@@ -13,14 +13,10 @@ import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json._
 
 import scala.util.Random
-import scala.util.hashing.MurmurHash3
 
-case object ExampleJson {
+object ExampleJson {
   val TrueStrings = Seq("t", "true", "y", "yes", "on", "1", "trueclass")
   val FalseStrings = Seq("f", "false", "n", "no", "off", "0", "falseclass")
-
-  def allFields(service: Service): ExampleJson = ExampleJson(service, Selection.All)
-  def requiredFieldsOnly(service: Service): ExampleJson = ExampleJson(service, Selection.RequiredFieldsOnly)
 }
 
 trait Selection
@@ -31,7 +27,10 @@ object Selection {
 
 case class UnknownType(typ: String) extends Throwable
 
-case class ExampleJson(service: Service, selection: Selection) {
+case class ExampleJson(
+  service: Service,
+  selection: Selection,
+  randomStringGenerator: RandomStringGenerator) {
 
   def sample(typ: String, subTyp: Option[String] = None): Option[JsValue] = {
     try {
@@ -365,8 +364,8 @@ case class ExampleJson(service: Service, selection: Selection) {
         .map(_.name)
         .getOrElse(Random.nextString(12))
     }
-    val hash = MurmurHash3.stringHash(seed).toString.takeRight(6)
-    s"lorem ipsum $hash"
+
+    randomStringGenerator.generate(seed)
   }
 
 }

--- a/postman-generator/src/main/scala/examples/RandomStringGenerator.scala
+++ b/postman-generator/src/main/scala/examples/RandomStringGenerator.scala
@@ -1,0 +1,26 @@
+package examples
+
+import scala.util.Random
+import scala.util.hashing.MurmurHash3
+
+trait RandomStringGenerator {
+  def generate(seed: String): String
+}
+
+object ScalaRandomStringGenerator extends RandomStringGenerator {
+
+  override def generate(seed: String): String = {
+    val string = randomStringStream.take(6).mkString
+    s"lorem ipsum $string"
+  }
+
+  private def randomStringStream: Stream[Char] =
+    Random.alphanumeric.dropWhile(_.isDigit)
+}
+
+object MurmurRandomStringGenerator extends RandomStringGenerator {
+  override def generate(seed: String): String = {
+    val hash = MurmurHash3.stringHash(seed).toString.takeRight(6)
+    s"lorem ipsum $hash"
+  }
+}

--- a/postman-generator/src/main/scala/examples/RandomStringGenerator.scala
+++ b/postman-generator/src/main/scala/examples/RandomStringGenerator.scala
@@ -11,7 +11,7 @@ object ScalaRandomStringGenerator extends RandomStringGenerator {
 
   override def generate(seed: String): String = {
     val string = randomStringStream.take(6).mkString
-    s"lorem ipsum $string"
+    s"lorem_ipsum_$string"
   }
 
   private def randomStringStream: Stream[Char] =
@@ -21,6 +21,6 @@ object ScalaRandomStringGenerator extends RandomStringGenerator {
 object MurmurRandomStringGenerator extends RandomStringGenerator {
   override def generate(seed: String): String = {
     val hash = MurmurHash3.stringHash(seed).toString.takeRight(6)
-    s"lorem ipsum $hash"
+    s"lorem_ipsum_$hash"
   }
 }

--- a/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
+++ b/postman-generator/src/main/scala/generator/PostmanCollectionGenerator.scala
@@ -1,6 +1,6 @@
 package generator
 
-import examples.{ExampleJson, Selection}
+import examples.{ExampleJson, RandomStringGenerator, ScalaRandomStringGenerator, Selection}
 import generator.Heuristics.PathVariable
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
 import io.apibuilder.spec.v0.models._
@@ -15,15 +15,9 @@ import Utils._
 import io.flow.postman.v0.models.{Folder, Item}
 import lib.Datatype.Primitive
 
-object PostmanCollectionGenerator extends CodeGenerator {
+class PostmanCollectionGenerator(randomStringGenerator: RandomStringGenerator) extends CodeGenerator {
 
   import scala.languageFeature.implicitConversions._
-
-  object Constants {
-    val BaseUrl = "BASE_URL"
-    val EntitiesSetup = "Entities Setup"
-    val EntitiesCleanup = "Entities Cleanup"
-  }
 
   override def invoke(form: InvocationForm): Either[Seq[String], Seq[File]] = {
     form.importedServices match {
@@ -69,7 +63,7 @@ object PostmanCollectionGenerator extends CodeGenerator {
       )
     }
 
-    val examplesProvider: ExampleJson = ExampleJson(service, Selection.All)
+    val examplesProvider: ExampleJson = ExampleJson(service, Selection.All, randomStringGenerator)
 
     val basicAuthOpt = service.attributes
       .find(_.name.equalsIgnoreCase(AttributeName.PostmanBasicAuth.toString))
@@ -111,7 +105,7 @@ object PostmanCollectionGenerator extends CodeGenerator {
       item = folders,
       variable = Seq(
         Utils.Variable(
-          key = Constants.BaseUrl,
+          key = PostmanGeneratorConstants.BaseUrl,
           value = baseUrl.getOrElse(""),
           `type` = Primitive.String.name
         )
@@ -157,3 +151,5 @@ object PostmanCollectionGenerator extends CodeGenerator {
     )
   }
 }
+
+object PostmanCollectionGeneratorImpl extends PostmanCollectionGenerator(ScalaRandomStringGenerator)

--- a/postman-generator/src/main/scala/generator/PostmanGeneratorConstants.scala
+++ b/postman-generator/src/main/scala/generator/PostmanGeneratorConstants.scala
@@ -1,0 +1,7 @@
+package generator
+
+object PostmanGeneratorConstants {
+  val BaseUrl = "BASE_URL"
+  val EntitiesSetup = "Entities Setup"
+  val EntitiesCleanup = "Entities Cleanup"
+}

--- a/postman-generator/src/main/scala/generator/PostmanItemBuilder.scala
+++ b/postman-generator/src/main/scala/generator/PostmanItemBuilder.scala
@@ -2,7 +2,6 @@ package generator
 
 import examples.ExampleJson
 import generator.Heuristics.PathVariable
-import generator.PostmanCollectionGenerator.Constants
 import generator.Utils.Description
 import io.apibuilder.spec.v0.models._
 import io.flow.postman.v0.{models => postman}
@@ -76,9 +75,9 @@ object PostmanItemBuilder extends Logging {
       }
 
     val postmanUrl = postman.Url(
-      raw = Some(s"{{${Constants.BaseUrl}}}" + operation.path),
+      raw = Some(s"{{${PostmanGeneratorConstants.BaseUrl}}}" + operation.path),
       protocol = None,
-      host = Some(Seq(s"{{${Constants.BaseUrl}}}")),
+      host = Some(Seq(s"{{${PostmanGeneratorConstants.BaseUrl}}}")),
       path = Some(operation.path.stripPrefix("/").split('/').toSeq),
       query = Some(queryParams),
       variable = Some(pathParams)

--- a/postman-generator/src/main/scala/generator/SetupCleanupFolderBuilder.scala
+++ b/postman-generator/src/main/scala/generator/SetupCleanupFolderBuilder.scala
@@ -2,7 +2,6 @@ package generator
 
 import akka.http.scaladsl.model.StatusCodes
 import examples.ExampleJson
-import generator.PostmanCollectionGenerator.Constants
 import io.apibuilder.spec.v0.models.{Operation, Parameter, ParameterLocation}
 import io.flow.postman.v0.models.{Folder, Item}
 import models.attributes.PostmanAttributes.ExtendedObjectReference
@@ -43,8 +42,8 @@ object SetupCleanupFolderBuilder {
     val setupSteps = setupItemToCleanupItemOpts.map(_._1)
     val cleanupSteps = setupItemToCleanupItemOpts.flatMap(_._2)
 
-    val setupFolderOpt = wrapInFolder(setupSteps, Constants.EntitiesSetup)
-    val cleanupFolderOpt = wrapInFolder(cleanupSteps, Constants.EntitiesCleanup)
+    val setupFolderOpt = wrapInFolder(setupSteps, PostmanGeneratorConstants.EntitiesSetup)
+    val cleanupFolderOpt = wrapInFolder(cleanupSteps, PostmanGeneratorConstants.EntitiesCleanup)
 
     setupFolderOpt -> cleanupFolderOpt
   }

--- a/postman-generator/src/test/scala/generator/FileInputOutputGeneratorTests.scala
+++ b/postman-generator/src/test/scala/generator/FileInputOutputGeneratorTests.scala
@@ -4,6 +4,7 @@ import io.apibuilder.generator.v0.models.InvocationForm
 import models.TestHelper._
 import org.scalatest.WordSpec
 import play.api.libs.json._
+import testUtils.TestPostmanCollectionGenerator
 
 import scala.io.Source
 
@@ -21,7 +22,7 @@ class FileInputOutputGeneratorTests extends WordSpec {
       val parsedService = service(inputFile)
 
       val invocationForm = InvocationForm(parsedService, importedServices = None)
-      val result = PostmanCollectionGenerator.invoke(invocationForm)
+      val result = TestPostmanCollectionGenerator.invoke(invocationForm)
 
       val files = result.getOrElse(fail("Generator invoke failure"))
       val str = files.head.contents

--- a/postman-generator/src/test/scala/generator/PostmanItemBuilderSpec.scala
+++ b/postman-generator/src/test/scala/generator/PostmanItemBuilderSpec.scala
@@ -123,7 +123,7 @@ class PostmanItemBuilderSpec extends WordSpec with Matchers {
     "build a POST request without example payload when Example Provider fails" in new TestContext {
       override val method = Method.Post
 
-      override val exampleProvider = new ExampleJson(null, null) {
+      override val exampleProvider = new ExampleJson(null, null, null) {
         override def sample(typ: String, subTyp: Option[String]): Option[JsValue] = {
           None
         }
@@ -146,7 +146,7 @@ class PostmanItemBuilderSpec extends WordSpec with Matchers {
     val path = "/resource/operation/all"
     val exampleJson = Json.obj("example" -> JsString("value"))
 
-    def exampleProvider: ExampleJson = new ExampleJson(null, null) {
+    def exampleProvider: ExampleJson = new ExampleJson(null, null, null) {
       override def sample(typ: String, subTyp: Option[String]): Option[JsValue] = {
         Some(exampleJson)
       }

--- a/postman-generator/src/test/scala/generator/PostmanTestAssertionsSpec.scala
+++ b/postman-generator/src/test/scala/generator/PostmanTestAssertionsSpec.scala
@@ -1,22 +1,21 @@
 package generator
 
 import io.apibuilder.generator.v0.models.{File, InvocationForm}
-import org.scalatest.{Assertion, Matchers, WordSpec}
-import play.api.libs.json.Json
 import io.flow.postman.v0.models._
 import io.flow.postman.v0.models.json.jsonReadsPostmanCollection
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.Json
+import testUtils.TestPostmanCollectionGenerator
 
 class PostmanTestAssertionsSpec extends WordSpec with Matchers {
 
-  import TestFixtures._
   import models.TestHelper.referenceApiService
-
 
   "Postman JS test assertions" should {
 
     "be added to GET, PUT, POST requests as simple 2xx status code check" in new TestContext {
       val invocationForm = InvocationForm(referenceApiService, importedServices = None)
-      val result = PostmanCollectionGenerator.invoke(invocationForm)
+      val result = TestPostmanCollectionGenerator.invoke(invocationForm)
 
       assertResultCollection(result) { collection =>
         val folders = collection.item.collect {
@@ -42,7 +41,7 @@ class PostmanTestAssertionsSpec extends WordSpec with Matchers {
 
     "not be added to the requests with the remaining methods" in new TestContext {
       val invocationForm = InvocationForm(referenceApiService, importedServices = None)
-      val result = PostmanCollectionGenerator.invoke(invocationForm)
+      val result = TestPostmanCollectionGenerator.invoke(invocationForm)
 
       assertResultCollection(result) { collection =>
         val folders = collection.item.collect {

--- a/postman-generator/src/test/scala/generator/ServiceImportResolverSpec.scala
+++ b/postman-generator/src/test/scala/generator/ServiceImportResolverSpec.scala
@@ -1,6 +1,6 @@
 package generator
 
-import examples.ExampleJson
+import examples.{ExampleJson, MurmurRandomStringGenerator, Selection}
 import io.apibuilder.spec.v0.models.Service
 import org.scalatest.{Assertion, Matchers, WordSpec}
 
@@ -81,7 +81,7 @@ class ServiceImportResolverSpec extends WordSpec with Matchers {
     }
 
     "prepare models in a way, which enables ExampleJson to prepare a sample JSON for every single one of them" in new ResolvedServiceTestContext {
-      val exampleProvider = ExampleJson.allFields(resultService)
+      val exampleProvider = ExampleJson(resultService, Selection.All, MurmurRandomStringGenerator)
       resultService.models.foreach { model =>
         val exampleProvided = exampleProvider.sample(model.name).isDefined
         assert(exampleProvided, s"// it should provide an example for ${model.name}")
@@ -110,7 +110,7 @@ class ServiceImportResolverSpec extends WordSpec with Matchers {
     }
 
     "prepare unions in a way, which enables ExampleJson to prepare a sample JSON for every single one of them" in new ResolvedServiceWithUnionsTestContext {
-      val exampleProvider = ExampleJson.allFields(resultService)
+      val exampleProvider = ExampleJson(resultService, Selection.All, MurmurRandomStringGenerator)
       resultService.unions.foreach { union =>
         val exampleProvided = exampleProvider.sample(union.name).isDefined
         assert(exampleProvided, s"// it should provide an example for ${union.name}")

--- a/postman-generator/src/test/scala/generator/SetupCleanupFolderBuilderSpec.scala
+++ b/postman-generator/src/test/scala/generator/SetupCleanupFolderBuilderSpec.scala
@@ -1,6 +1,6 @@
 package generator
 
-import examples.ExampleJson
+import examples.{ExampleJson, MurmurRandomStringGenerator, Selection}
 import generator.TestFixtures.TrivialServiceWithImportAndDependencyCtx
 import io.flow.postman.v0.models.{EventType, Folder, Header}
 import models.attributes.PostmanAttributes.ExtendedObjectReference
@@ -80,7 +80,7 @@ class SetupCleanupFolderBuilderSpec extends WordSpec with Matchers {
     lazy val objReferenceAttrToOperationTuples: Seq[(ExtendedObjectReference, DependantOperations)] =
       Seq(objectRef1AttrValue.toExtended -> defaultTargetOp)
     lazy val serviceSpecificHeaders: Seq[Header] = Seq.empty
-    lazy val exampleProvider: ExampleJson = ExampleJson.allFields(testMainService)
+    lazy val exampleProvider: ExampleJson = ExampleJson(testMainService, Selection.All, MurmurRandomStringGenerator)
 
     lazy val (setupFolderOpt, cleanupFolderOpt) =
       SetupCleanupFolderBuilder.prepareDependantEntitiesSetupAndCleanup(objReferenceAttrToOperationTuples, serviceSpecificHeaders, exampleProvider)

--- a/postman-generator/src/test/scala/testUtils/TestPostmanCollectionGenerator.scala
+++ b/postman-generator/src/test/scala/testUtils/TestPostmanCollectionGenerator.scala
@@ -1,0 +1,6 @@
+package testUtils
+
+import examples.MurmurRandomStringGenerator
+import generator.PostmanCollectionGenerator
+
+object TestPostmanCollectionGenerator extends PostmanCollectionGenerator(MurmurRandomStringGenerator)


### PR DESCRIPTION
`RandomStringGenerator` trait is created.
It is used to parametrize `ExampleJson`and then the whole `PostmanCollectionGenerator`